### PR TITLE
Initial pass at app heartbeats. Meant to signal to ProcessCaddy that …

### DIFF
--- a/ProcessCaddy/Database.cs
+++ b/ProcessCaddy/Database.cs
@@ -27,7 +27,7 @@ namespace ProcessCaddy
 
 		public bool Load( string path )
 		{
-			using (StreamReader reader = new StreamReader( path ))
+			using ( StreamReader reader = new StreamReader( path ) )
 			{
 				if ( reader == null )
 				{

--- a/ProcessCaddy/Form1.cs
+++ b/ProcessCaddy/Form1.cs
@@ -9,11 +9,20 @@ namespace ProcessCaddy
     {
 		ProcessManager m_processManager = new ProcessManager();
 		Database m_database = new Database();
+		Timer m_timer = new Timer();
 
         public Form1()
         {
             InitializeComponent();
+			m_timer.Tick += Update;
+			m_timer.Interval = 1000;
+			m_timer.Enabled = true;
         }
+
+		void Update(object sender, EventArgs e)
+		{
+			m_processManager.Update();
+		}
 
 		private void listView1_DrawColumnHeader( object sender, DrawListViewColumnHeaderEventArgs e )
 		{

--- a/ProcessCaddy/HeartbeatMonitor.cs
+++ b/ProcessCaddy/HeartbeatMonitor.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Net;
+using System.Text;
+using System.Runtime.Serialization.Formatters.Binary;
+
+namespace ProcessCaddy
+{
+	public class HeartbeatMonitor
+	{
+		IProcessManager m_processManager;
+		UdpClient m_Peer;
+		List<int> m_pidsToValidate = new List<int>();
+		static object s_lockObject = new object();
+		Dictionary<int, MonitoredProcess> m_processes = new Dictionary<int, MonitoredProcess>();
+
+		struct MonitoredProcess
+		{
+			public MonitoredProcess( int pid )
+			{
+				m_pid = pid;
+				m_startTime = DateTime.Now;
+			}
+
+			public int m_pid;
+			public DateTime m_startTime;
+
+		}
+
+		public HeartbeatMonitor(IProcessManager mgr)
+		{
+			m_processManager = mgr;
+
+			//start server
+			CreateSocket(25002);
+		}
+
+		public void Update()
+		{
+			//handle any incoming commands...
+			lock (s_lockObject)
+			{
+				foreach (int pid in m_pidsToValidate)
+				{
+					//
+					if (m_processManager.FindProcessById(pid))
+					{
+						MonitoredProcess proc;
+						if ( m_processes.TryGetValue( pid, out proc ) )
+						{
+							m_processes[pid] = new MonitoredProcess(pid);
+						} else
+						{
+							m_processes.Add( pid, new MonitoredProcess(pid));
+						}
+					}
+				}
+				m_pidsToValidate.Clear();
+
+				//check for missing pids
+				
+				foreach( var pair in m_processes )
+				{
+					if ( !m_processManager.FindProcessById( pair.Key ) )
+					{
+						m_pidsToValidate.Add(pair.Key);
+					}
+				}
+
+				foreach( int pid in m_pidsToValidate )
+				{
+					m_processes.Remove(pid);
+				}
+				m_pidsToValidate.Clear();
+
+				//check for pid timeouts
+				foreach (var pair in m_processes)
+				{
+					int secondsSinceLastHeartbeat = (DateTime.Now - pair.Value.m_startTime).Seconds;
+					if ( secondsSinceLastHeartbeat >= 30 )
+					{
+						Console.WriteLine("Restart " + pair.Key );
+						m_processManager.RestartProcessById(pair.Key);
+					}
+				}
+			}
+		}
+
+		private bool CreateSocket(int port)
+		{
+			//int orgPort = port;
+			m_Peer = new UdpClient();
+			m_Peer.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+
+			try
+			{
+				IPEndPoint localpt = new IPEndPoint(IPAddress.Any, port);
+				m_Peer.Client.Bind(localpt);
+				m_Peer.EnableBroadcast = false;
+				m_Peer.BeginReceive(new AsyncCallback(recv), null);
+				return true;
+			}
+			catch (System.Exception e )
+			{
+				Console.WriteLine(  e.ToString() );
+			}
+
+			return false;
+		}
+
+		void recv(IAsyncResult res)
+		{
+			try
+			{
+				IPEndPoint remote = new IPEndPoint(IPAddress.Any, 0);
+				byte[] bytes = m_Peer.EndReceive(res, ref remote);
+
+				string msg = Decode(bytes);
+				if (int.TryParse(msg, out int pid))
+				{
+					lock (s_lockObject)
+					{
+						m_pidsToValidate.Add(pid);
+					}
+				}
+
+			}
+			catch (System.Exception e)
+			{
+				Console.WriteLine(e.ToString());
+			}
+
+			// Wait for the next packet
+			m_Peer.BeginReceive(recv, null);
+		}
+
+		protected virtual string Decode(byte[] bytes)
+		{
+			return ASCIIEncoding.ASCII.GetString(bytes);
+		}
+
+		protected virtual byte[] Encode(string msg)
+		{
+			return Encoding.ASCII.GetBytes(msg);
+		}
+
+		// Serialize to bytes (BinaryFormatter)
+		public static byte[] SerializeToBytes<T>(T source)
+		{
+			using (var stream = new MemoryStream())
+			{
+				try
+				{
+					var formatter = new BinaryFormatter();
+					formatter.Serialize(stream, source);
+					return stream.ToArray();
+				}
+				catch (System.Exception) { }
+
+				return null;
+			}
+		}
+
+		// Deerialize from bytes (BinaryFormatter)
+		public static T DeserializeFromBytes<T>(byte[] source) where T : Packet
+		{
+			using (var stream = new MemoryStream(source))
+			{
+				try
+				{
+					var formatter = new BinaryFormatter();
+					stream.Seek(0, SeekOrigin.Begin);
+					return (T)formatter.Deserialize(stream);
+				}
+				catch (System.Exception e )
+				{
+					Console.WriteLine( e.ToString() );
+				}
+				return null;
+			}
+		}
+	}
+}

--- a/ProcessCaddy/IProcessManager.cs
+++ b/ProcessCaddy/IProcessManager.cs
@@ -1,0 +1,8 @@
+﻿namespace ProcessCaddy
+{
+	public interface IProcessManager
+	{
+		bool FindProcessById( int pid );
+		void RestartProcessById( int pid );
+	}
+}

--- a/ProcessCaddy/Packet.cs
+++ b/ProcessCaddy/Packet.cs
@@ -1,0 +1,30 @@
+﻿namespace ProcessCaddy
+{
+	[System.Serializable]
+	public class Packet
+	{
+		private const uint VERSION = 1;
+		private const uint SPECIAL = 0xCAFECAFE;
+
+		public Packet(byte[] _bytes)
+		{
+			m_version = VERSION;
+			m_special = SPECIAL;
+			m_bytes = _bytes;
+		}
+
+		public bool IsValid
+		{
+			get
+			{
+				return (m_version == VERSION) && (m_special == SPECIAL);
+			}
+		}
+
+		private uint m_version;
+		private uint m_special;
+
+		//FIXME: this should be private
+		public byte[] m_bytes;
+	}
+}

--- a/ProcessCaddy/ProcessCaddy.csproj
+++ b/ProcessCaddy/ProcessCaddy.csproj
@@ -70,6 +70,9 @@
     <Compile Include="Form2.Designer.cs">
       <DependentUpon>Form2.cs</DependentUpon>
     </Compile>
+    <Compile Include="HeartbeatMonitor.cs" />
+    <Compile Include="IProcessManager.cs" />
+    <Compile Include="Packet.cs" />
     <Compile Include="ProcessManager.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
…it should monitor for app hangs. The app can opt-in by sending its process id to ProcessCaddy via a UDP message every few seconds. If greater than 30 seconds passes without a heartbeat, ProcessCaddy will restart that process. If the app does not send any heartbeats at all, then it does not opt-in to this service.